### PR TITLE
Article thumbnails for SEO purposes

### DIFF
--- a/_characters/arlee-summers.markdown
+++ b/_characters/arlee-summers.markdown
@@ -8,8 +8,8 @@ excerpt_separator: <!--END_EXCERPT-->
 epithet: "Ultimate Escort"
 creator: Chidori
 
-thumbnail: /assets/images/Characters/ArleeThumbnail.png
-thumbnail_caption: Art by Mads
+image: /assets/images/Characters/ArleeThumbnail.png
+image_caption: Art by Mads
 
 quote: I've lost so much, but I promised I would never sit still.
   I have to keep fighting!

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,8 +11,4 @@
 
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico"/>
 
-  {%- if page.thumbnail -%}
-    <meta name="og:image" content="{{page.thumbnail | absolute_url }}">
-  {%- endif -%}
-
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico"/>
 
   {%- if page.thumbnail -%}
-    <meta name="og:image" content="{{page.thumbnail | relative_url}}">
+    <meta name="og:image" content="{{page.thumbnail | absolute_url }}">
   {%- endif -%}
 
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,4 +10,9 @@
   {%- endif -%}
 
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico"/>
+
+  {%- if page.thumbnail -%}
+    <meta name="og:image" content="{{page.thumbnail | relative_url}}">
+  {%- endif -%}
+
 </head>

--- a/_layouts/character_simple.html
+++ b/_layouts/character_simple.html
@@ -59,9 +59,9 @@ layout: default
 
   <div class="post-content character-simple">
     <!-- Thumbnail -->
-    {% if page.thumbnail %}
-      {% include figure.html image=page.thumbnail
-        caption=page.thumbnail_caption width="100"
+    {% if page.image %}
+      {% include figure.html image=page.image
+        caption=page.image_caption width="100"
         style="float:right; margin-left: 0.5em;" %}
     {% endif %}
 

--- a/characters.html
+++ b/characters.html
@@ -17,7 +17,7 @@ title: Characters
 <ul class="post-list">
   {% for character in site.characters %}
   <article class="character-short__entry">
-    {% include figure.html image=character.thumbnail caption=character.thumbnail_caption width="100" style="float:right; margin-left: 0.5em" %}
+    {% include figure.html image=character.image caption=character.image_caption width="100" style="float:right; margin-left: 0.5em" %}
     <header>
       <h2><a href="{{character.url}}">{{ character.title }}</a></h2>
       <p class="post-meta">


### PR DESCRIPTION
Added support for thumbnails for SEO tags by doing the following:
- Renamed `thumbnail` field in character pages to the `image` field, allowing thumbnails to be handled by the SEO plugin.
- Renamed `thumbnail_caption` field in character pages to the `image_caption` field for parity with the previous change.