### PR TITLE
Feat/stories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,8 @@ collections:
     output: true
   art:
     output: true
+  stories:
+    output: true
 
 emptyArray: []
 

--- a/_layouts/journal.html
+++ b/_layouts/journal.html
@@ -16,7 +16,41 @@ layout: default
     background-color: #FFAAAA;
     text-decoration: line-through;
   }
+
+  .journal__nav-adjacent {
+    text-align: center;
+  }
 </style>
+
+{% assign story_posts = site.categories.journal | where:'story', page.story %}
+{% for post in story_posts %}
+  {% if post.url == page.url %}
+    {% assign prevOffset = forloop.index0 | minus: 1 %}
+    {% assign nextOffset = prevOffset | plus: 2 %}
+    {% if forloop.first == false %}
+      {% assign story_next_post = story_posts[prevOffset] %}
+    {% endif %}
+    {% if forloop.last == false %}
+      {% assign story_prev_post = story_posts[nextOffset] %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+{% capture nav_adjacent %}
+  <nav class="journal__nav-adjacent">
+    {% assign my_story = site.stories | where:"story_id",page.story | first %}
+    <p>
+      <a href="{{my_story.url}}">Story - {{my_story.title}}</a>
+      <br>
+      {% if story_prev_post %}
+        <a href="{{story_prev_post.url}}">&lt; Previous </a> //
+      {% endif %}
+      <a href="{{page.url}}">Permalink</a>
+      {% if story_next_post %}
+        // <a href="{{story_next_post.url}}"> Next &gt;</a>
+      {% endif %}
+    </p>
+  </nav>
+{% endcapture %}
 
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 
@@ -60,6 +94,8 @@ layout: default
         </p>
       {% endif %}
 
+      <!-- AdjacentNav -->
+      {{ nav_adjacent }}
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">
@@ -71,4 +107,8 @@ layout: default
   {%- endif -%}
 
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+
+  <footer>
+    {{ nav_adjacent }}
+  </footer>
 </article>

--- a/_layouts/story.html
+++ b/_layouts/story.html
@@ -1,0 +1,47 @@
+---
+layout: page
+---
+<style>
+.character-link {
+  display: inline-block;
+  border: 1px solid lightgrey;
+  padding: 2px 5px;
+  border-radius: 5px;
+}
+.character-link, .character-link:visited, .character-link:hover {
+  color: inherit;
+}
+.character-link--invalid, .character-link--invalid:hover {
+  background-color: #FFAAAA;
+  text-decoration: line-through;
+}
+</style>
+
+<!-- Character list -->
+{% assign character_ids = page.characters | split: " " %}
+{% if character_ids != empty %}
+  <p>
+    <strong>Characters: </strong>
+    {% for character_id in character_ids %}
+      {% include link-character.html character_id=character_id %}
+    {% endfor %}
+  </p>
+{% endif %}
+
+<!-- Main contents -->
+{{content}}
+
+{% assign journal_entries = site.categories.journal %}
+{% assign journal_entries = journal_entries | where:'story',page.story_id %}
+{% if journal_entries.size != 0 %}
+  <h2>Journal Entries</h2>
+  <ul>
+    {% assign sorted = journal_entries | sort: 'date' %}
+    {% for entry in sorted %}
+      <li>
+        <a href="{{entry.url}}">{{entry.title}}</a> <br>
+        <span>{{entry.description}}</span>
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}

--- a/_posts/journal/2021-06-24-journal-lilah-0.markdown
+++ b/_posts/journal/2021-06-24-journal-lilah-0.markdown
@@ -3,8 +3,11 @@ layout: journal
 title: "Horde of the Dragon Queen - Introductions"
 date: 2021-06-24 13:40:00 -0400
 
+story: hotdq-lexi
 categories: journal
 tags: character_lilah-redbud
+
+description: Lilah reflects on her traveling companions on the way to Greenest.
 ---
 My name is Lilah Redbud. I'm a warrior from the former fairy colony of
 Wellglen. Folks back home call me "Lilah the Tall" because I tower over

--- a/_posts/journal/2021-06-24-journal-lilah-1.markdown
+++ b/_posts/journal/2021-06-24-journal-lilah-1.markdown
@@ -3,8 +3,12 @@ layout: journal
 title: "Horde of the Dragon Queen - Session 1: Dragon Over Greenest"
 date: 2021-06-24 14:25:00 -0400
 
+story: hotdq-lexi
 categories: journal
 tags: character_lilah-redbud
+
+description: The group arrives at a town in dire need of heroes, and fight
+  their way to the keep in search of answers.
 ---
 We see the smoke long before the buildings come into view. As we grow nearer,
 the smell of ash is undeniable, as is the silhouette of the massive blue lizard

--- a/_posts/journal/2021-06-24-journal-lilah-2.markdown
+++ b/_posts/journal/2021-06-24-journal-lilah-2.markdown
@@ -3,8 +3,12 @@ layout: journal
 title: "Horde of the Dragon Queen - Session 2: The Rat Tunnel"
 date: 2021-06-24 15:36:00 -0400
 
+story: hotdq-lexi
 categories: journal
 tags: character_lilah-redbud
+
+description: Lilah helps open the way out of Castle Greenest and protects her
+  allies from dark forces.
 ---
 We enter the castle courtyard and talk to the town's leaders, Governor Nighthill and Castellan Escobert. Because he recognizes our immense combat skill as first level adventurers, Escobert asks us to open up a the exit of a secret tunnel under the keep to allow easy access in and out of the castle. We agree to help out, since preventing the town from getting overrun will help us to eventually not die. Escobert warns us that there may be rats in the tunnel, and that we need to find a key (likely somewhere in the tunnel) to open it.
 

--- a/_posts/journal/2021-06-24-journal-lilah-3.markdown
+++ b/_posts/journal/2021-06-24-journal-lilah-3.markdown
@@ -3,8 +3,12 @@ layout: journal
 title: "Horde of the Dragon Queen - Session 3: The Siege of Castle Greenest"
 date: 2021-06-24 16:10:00 -0400
 
+story: hotdq-lexi
 categories: journal
 tags: character_lilah-redbud
+
+description: The group learns of the Queen of Dragons and protects the
+  civilians in the keep from the besieging cultists.
 ---
 In an instant, we are surrounded. Like the previous group, this raiding party contains kobolds and a couple of humanoid mooks in purple robes, but something is different this time. They seem a little more organized, like they have a plan. And what was that strange sound I heard? As we fight on, it doesn't take long before my question is answered: Some kind of drake pounces on us from a nearby thicket. Much of this battle is a blur in my mind. Arcello went down, but was healed by Rubik. At last only one of the cultists remained, and we knocked them unconscious, leaving them alive for questioning.
 

--- a/_posts/journal/2021-06-24-journal-lilah-4a.markdown
+++ b/_posts/journal/2021-06-24-journal-lilah-4a.markdown
@@ -3,8 +3,12 @@ layout: journal
 title: "Horde of the Dragon Queen - Session 4a: Breath of the Blue Dragon [LILAH END]"
 date: 2021-06-24 16:15:00 -0400
 
+story: hotdq-lexi
 categories: journal
 tags: character_lilah-redbud
+
+description: Lilah Redbud is faced with the threat of an adult dragon, and
+  fights until her last breath.
 ---
 As we plot how we are going to deal with the situation in the mill, we hear a loud thump on the roof of the keep above us. We exit the keep to investigate, and we realize that the big adult dragon we saw earlier in the day has landed on the keep. Soldiers and civilians alike man the nearby ballistae, and the *real heroes* attack from afar with their weapons.
 

--- a/_posts/journal/_YYYY-MM-DD_example-entry.markdown
+++ b/_posts/journal/_YYYY-MM-DD_example-entry.markdown
@@ -1,0 +1,12 @@
+---
+layout: journal
+title: Example Journal Entry
+date: YYYY-MM-DD hh:mm:ss -0400
+
+story: # story_id of a story to associate this journal entry with
+categories: journal
+tags: # To include characters, list character_id prepended with `character_`
+        # For example: character_lilah-redbud character_arlee-summers
+
+description: # Short, 1-2 sentence description of what happens
+---

--- a/_stories/_example-story.markdown
+++ b/_stories/_example-story.markdown
@@ -1,0 +1,16 @@
+---
+layout: story
+title: Example Story
+date: YYYY-MM-DD hh:mm:ss -0400
+
+excerpt_separator: <!--END_EXCERPT-->
+
+story_id: example-story # Unique identifier to the story
+characters: # List of character_id that are important to the story.
+---
+A short, one-paragraph hook for the story goes here. This hook is used for
+excerpts.
+
+<!--END_EXCERPT-->
+
+The rest of the description goes here

--- a/_stories/hotdq-lexi.markdown
+++ b/_stories/hotdq-lexi.markdown
@@ -22,7 +22,7 @@ currently in the party:
 | Name              | Ancestry/Class      | Player    | Joined    |
 | ----------------- | ------------------- | --------- | --------- |
 | Kosilius          | Human Fighter, NB   | Howling   | Session 1 |
-| Balthus Frostbite | Human? Wizard, NB   | Jade      | Session 1 |
+| Balthus Frostbite | Human Wizard, NB   | Jade      | Session 1 |
 | Eloen             | Elf Life Cleric, F  | Piper     | Session 1 |
 | Arcello           | Human? Bard, F      | Jammy     | Session 1 |
 | Mercury Wolfhound | Human Warlock, F    | Emmia     | Session 4 |

--- a/_stories/hotdq-lexi.markdown
+++ b/_stories/hotdq-lexi.markdown
@@ -1,0 +1,43 @@
+---
+layout: story
+title: Horde of the Dragon Queen (Lexi's D&D Campaign)
+date: 2021-06-25 19:00:00 -0400
+
+excerpt_separator: <!--END_EXCERPT-->
+
+story_id: hotdq-lexi
+characters: lilah-redbud
+---
+The Cult of the Dragon is attacking the Sword Coast, aiming to bring Tiamat,
+Queen of the Chromatic Dragons into the world. A ragtag group of adventurers
+is caught in their crosshairs. Will they become the heroes the world needs in
+this time of danger?
+
+<!--END_EXCERPT-->
+
+## Cast
+In addition to the game master Lexi, the following player characters are
+currently in the party:
+
+| Name              | Ancestry/Class      | Player    | Joined    |
+| ----------------- | ------------------- | --------- | --------- |
+| Kosilius          | Human Fighter, NB   | Howling   | Session 1 |
+| Balthus Frostbite | Human? Wizard, NB   | Jade      | Session 1 |
+| Eloen             | Elf Life Cleric, F  | Piper     | Session 1 |
+| Arcello           | Human? Bard, F      | Jammy     | Session 1 |
+| Mercury Wolfhound | Human Warlock, F    | Emmia     | Session 4 |
+
+Additionally, the following non-player characters are in the party:
+
+| Name              | Ancestry/Class      | Joined    |
+| ----------------- | ------------------- | --------- |
+| Rubik             | Dwarf Paladin, M    | Session 1
+
+### The Fallen
+The following player characters have met their demise over the course of the
+module. They will be missed.
+{% capture fallen_lilah %} [Lilah Redbud the Tall]({% link _characters/lilah-redbud.markdown %}) {% endcapture %}
+
+| Name              | Ancestry/Class   | Player | Joined    | Died      |
+| ----------------- | ---------------- | ------ | --------- | --------- |
+| {{fallen_lilah}}  | Fairy Fighter, F | Emmia  | Session 1 | Session 4 |

--- a/characters.html
+++ b/characters.html
@@ -23,7 +23,7 @@ title: Characters
   }
 </style>
 
-<h1 class="page-heading">{{Characters}}</h1>
+<h1 class="page-heading">{{page.title}}</h1>
 
 <ul class="post-list">
   {% for character in site.characters %}

--- a/stories.html
+++ b/stories.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Stories
+---
+
+<h1 class="page-heading">{{page.title}}</h1>
+
+<ul class="post-list">
+  {% for story in site.stories %}
+    <div class="story-short__entry">
+      <header>
+        <h2><a href="{{story.url}}">{{story.title}}</a></h2>
+      </header>
+      <p> {{ story.excerpt }}</p>
+      <footer>
+        <a href="{{story.url}}">(Read more)</a>
+      </footer>
+    </div>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
Makes the following feature changes:
- Adds Story collection to `config.yml`
- Adds layout for story pages, which has the following features:
  - Lists site characters associated with the story
  - Lists journal entries that are part of the story
- Adds a page with a list of stories, which is linked from the main navbar
- Adds non-rendering example pages for journal entry and story pages
- Adds navlinks to the net and previous story pages, as well as the associated story, to the journal layout


Makes the following content changes:
- Adds a story page for Lexi's Horde of the Dragon Queen D&D game
- Adds story and description to existing journal entries

Fixes the following:
- Fixes an issue where the Characters page does not display its title 

Closes #9 